### PR TITLE
CAS updates

### DIFF
--- a/public/js/cas.json
+++ b/public/js/cas.json
@@ -3,7 +3,7 @@
     "title": "Aberdeen",
     "address": "41 Union Street\nAberdeen\nAB11 5BN",
     "phone": "01224 569 750",
-    "hours": "",
+    "hours": "Monday to Friday, 9am to 5pm",
     "lat": 57.14722339999999,
     "lng": -2.0959203,
     "id": "c002c214-7a39-4ff2-b21f-a4f3b45b14a1"
@@ -12,7 +12,7 @@
     "title": "Airdrie",
     "address": "Resource Centre\n14 Anderson Street\nAirdrie\nML6 0AA",
     "phone": "01236 754 109",
-    "hours": "",
+    "hours": "Monday, 9am to 7:30pm\nTuesday to Friday, 9am to 4:30pm",
     "lat": 55.8669483,
     "lng": -3.9820245,
     "id": "ead14905-96be-4032-bdf5-2e076efb27bc"
@@ -21,7 +21,7 @@
     "title": "Arbroath",
     "address": "11 Millgate\nArbroath\nDD11 1NN",
     "phone": "01241 870661 ext 25",
-    "hours": "",
+    "hours": "Monday to Friday, 9am to 5pm",
     "lat": 56.5581472,
     "lng": -2.5863387,
     "id": "c55496a1-2c34-4ddb-a2e7-5e18367ce256"
@@ -30,7 +30,7 @@
     "title": "Forfar",
     "address": "19 Queen Street\nForfar\nDD8 3AJ",
     "phone": "01241 870661 ext 25",
-    "hours": "",
+    "hours": "Monday to Friday, 9am to 5pm",
     "lat": 56.645145,
     "lng": -2.8875885,
     "id": "0e57a050-bd51-42f7-bedf-65df38b8e26e"
@@ -39,7 +39,7 @@
     "title": "Montrose",
     "address": "32 Castle Street\nMontrose\nDD10 8AG",
     "phone": "01241 870661 ext 25",
-    "hours": "",
+    "hours": "Monday to Friday, 9am to 5pm",
     "lat": 56.708893,
     "lng": -2.4706502,
     "id": "18bfeb4e-3b8b-4dd6-adc6-5351ec54ef71"
@@ -48,7 +48,7 @@
     "title": "Annan",
     "address": "19a Bank Street\nAnnan\nDG12 6AA",
     "phone": "0300 303 4321",
-    "hours": "",
+    "hours": "Monday to Friday, 9am to 5pm",
     "lat": 54.9869107,
     "lng": -3.262255,
     "id": "37516769-0325-430d-a7f6-e40f4ebd8e10"
@@ -57,7 +57,7 @@
     "title": "Lochgilphead",
     "address": "Riverside\nOban Road\nLochgilphead\nPA31 8NG",
     "phone": "08456 123808",
-    "hours": "",
+    "hours": "Monday, Tuesday, Thursday, Friday, 10am to 1pm and 2pm to 4pm\nWednesday, 10am to 1pm and 2pm to 7pm",
     "lat": 56.0438038,
     "lng": -5.441284599999999,
     "id": "e50a0813-d8bc-422b-b0f0-0850992f5ba4"
@@ -66,7 +66,7 @@
     "title": "Helensburgh",
     "address": "65-67 West Princes Street\nHelensburgh\nG84 8BN",
     "phone": "08456 123808",
-    "hours": "",
+    "hours": "Monday, Tuesday, Thursday, Friday, 10am to 1pm and 2pm to 4pm\nWednesday, 10am to 1pm and 2pm to 7pm",
     "lat": 56.0046889,
     "lng": -4.738566899999999,
     "id": "7546ac30-5cba-4329-b49d-6ef30506731c"
@@ -75,7 +75,7 @@
     "title": "Arran",
     "address": "Ormidale Sports Centre\nShore Road\nBrodick\nKA27 8DL",
     "phone": "01294 608 147",
-    "hours": "",
+    "hours": "Monday, 9:30am to 1:30pm",
     "lat": 55.5772177,
     "lng": -5.152120399999999,
     "id": "b5dd79cd-6b49-4f97-8c70-8106a8fd6212"
@@ -84,7 +84,7 @@
     "title": "Banff and Buchan",
     "address": "Townhouse\nBroad Street\nPeterhead\nAB42 1BY",
     "phone": "01779 471515",
-    "hours": "",
+    "hours": "Monday, Tuesday, Thursday, Friday, 9:30am to 2:30pm",
     "lat": 57.5047776,
     "lng": -1.7769888,
     "id": "72b7cc89-b147-4e8e-ac81-b112428c32d2"
@@ -93,7 +93,7 @@
     "title": "Barra",
     "address": "Castlebay\nIsle of Barra\nHS9 5XD",
     "phone": "01871 810608",
-    "hours": "",
+    "hours": "Monday, 1:30pm to 4pm\nTuesday, Wednesday, 9:30am to 1pm and 1:30pm to 4:30pm",
     "lat": 56.9552008,
     "lng": -7.489373199999999,
     "id": "dc6b9656-29b3-4c9b-9672-534e67d71887"
@@ -102,7 +102,7 @@
     "title": "Bellshill",
     "address": "6 Hamilton Road\nBellshill\nML4 1AQ",
     "phone": "01698 748615",
-    "hours": "",
+    "hours": "Monday to Friday, 10am to 4pm",
     "lat": 55.8184733,
     "lng": -4.0257939,
     "id": "a2b7d5d5-fd01-4353-a8be-3aceebb191d2"
@@ -111,7 +111,7 @@
     "title": "Thurso",
     "address": "1A Beach Court\nThurso\nKW14 8AD",
     "phone": "01847 894243",
-    "hours": "",
+    "hours": "Monday to Friday, 10am to 2pm",
     "lat": 58.59550280000001,
     "lng": -3.5198997,
     "id": "7d04db02-c5c5-4161-8b7b-5929ae2046f5"
@@ -120,7 +120,7 @@
     "title": "Wick",
     "address": "123 High Street\nWick\nKW1 4LR",
     "phone": "01955 605989",
-    "hours": "",
+    "hours": "Tuesday, Wednesday, Thursday, 10am to 2pm",
     "lat": 58.4426405,
     "lng": -3.0900055,
     "id": "1f6334a9-3f52-4ddd-9e60-c46fe05eddcc"
@@ -129,7 +129,7 @@
     "title": "Castle Douglas",
     "address": "3 St Andrew Street\nCastle Douglas\nDG7 1DE",
     "phone": "0300 303 4321",
-    "hours": "",
+    "hours": "Monday to Friday, 9am to 5pm",
     "lat": 54.9392795,
     "lng": -3.932960899999999,
     "id": "05e60f20-5601-47a8-b183-e6c76f532a21"
@@ -138,7 +138,7 @@
     "title": "Central Borders",
     "address": "111 High Street\nGalashiels\nTD1 1RZ",
     "phone": "01896 753889",
-    "hours": "",
+    "hours": "Monday, Wednesday, Friday, 10am to 1pm\nTuesday, 10am to 4pm\nThursday 10am to 6pm",
     "lat": 55.6185398,
     "lng": -2.811775,
     "id": "ca04da6b-850f-4035-9c4c-b4f973f70980"
@@ -147,7 +147,7 @@
     "title": "Cowdenbeath",
     "address": "322 High Street\nCowdenbeath\nKY4 9NT",
     "phone": "0345 1400 095",
-    "hours": "",
+    "hours": "Monday to Friday, 8:30am to 4pm",
     "lat": 56.1098144,
     "lng": -3.3431333,
     "id": "4239eda5-25d5-46a9-90c1-b03fd21abc35"
@@ -156,7 +156,7 @@
     "title": "Cupar",
     "address": "Local County buildings\nSt Catherine Street\nCupar\nKY15 4TA",
     "phone": "0345 1400 095",
-    "hours": "",
+    "hours": "Monday to Friday, 8:30am to 4pm",
     "lat": 56.3194962,
     "lng": -3.0103638,
     "id": "49f8f6d5-0274-474f-829d-84f92673f235"
@@ -165,7 +165,7 @@
     "title": "Dunfermline",
     "address": "4 Abbey Park Place\nDunfermline\nKY12 7PD",
     "phone": "0345 1400 095",
-    "hours": "",
+    "hours": "Monday to Friday, 8:30am to 4pm",
     "lat": 56.069997,
     "lng": -3.4607091,
     "id": "771a583e-05b3-4ddd-9013-b6697349f24f"
@@ -174,7 +174,7 @@
     "title": "Glenrothes",
     "address": "10 - 12 Pentland Court\nSaltire Centre\nGlenrothes\nKY6 2DA",
     "phone": "0345 1400 095",
-    "hours": "",
+    "hours": "Monday to Friday, 8:30am to 4pm",
     "lat": 56.1893429,
     "lng": -3.1844721,
     "id": "3f34a89b-b08e-485c-9146-4c92169dfe7b"
@@ -183,7 +183,7 @@
     "title": "Kirkcaldy",
     "address": "15 Wemyssfield\nKirkcaldy\nKY1 1XN",
     "phone": "0345 1400 095",
-    "hours": "",
+    "hours": "Monday to Friday, 8:30am to 4pm",
     "lat": 56.11117119999999,
     "lng": -3.1639852,
     "id": "8fcccbd5-1f34-4f89-9b7f-adaf4417b549"
@@ -192,7 +192,7 @@
     "title": "Leven",
     "address": "The Adam Smith College\nVictoria Road\nLeven\nKY8 4RN",
     "phone": "0345 1400 095",
-    "hours": "",
+    "hours": "Monday to Friday, 8:30am to 4pm",
     "lat": 56.170838,
     "lng": -3.0383031,
     "id": "692be951-f991-4e1a-b8dc-7313b60e10e9"
@@ -201,7 +201,7 @@
     "title": "West Lothian",
     "address": "Unit 1\nAlmondbank Centre\nShiel Walk\nLivingston\nEH54 5EH",
     "phone": "01506 444814",
-    "hours": "",
+    "hours": "Monday to Friday, 9am to 5pm",
     "lat": 55.8966532,
     "lng": -3.4972636,
     "id": "d547d683-3da6-419b-a77b-15de065e7b67"
@@ -210,7 +210,7 @@
     "title": "Glasgow",
     "address": "2nd Floor\nBrunswick House\n51 Wilson Street\nGlasgow\nG1 1UZ",
     "phone": "0808 800 9060",
-    "hours": "",
+    "hours": "Monday to Friday, 9am to 5pm",
     "lat": 55.85849109999999,
     "lng": -4.247635799999999,
     "id": "aa7425cf-48f5-474f-870a-887d117c9f99"
@@ -219,7 +219,7 @@
     "title": "Edinburgh (Dundas Street)",
     "address": "58 Dundas Street\nEdinburgh\nEH3 6QZ",
     "phone": "0131 555 3907",
-    "hours": "",
+    "hours": "Monday to Friday, 9am to 5pm",
     "lat": 55.95809,
     "lng": -3.2000949,
     "id": "e28ba8d7-da7c-4f57-8a97-3a28db685ce4"
@@ -228,7 +228,7 @@
     "title": "Gorgie/Dalry",
     "address": "Fountainbridge Library\n137 Dundee Street\nEdinburgh\nEH11 1BG",
     "phone": "0131 555 3907",
-    "hours": "",
+    "hours": "Monday to Friday, 9am to 5pm",
     "lat": 55.9402762,
     "lng": -3.2183327,
     "id": "d86a600f-609e-42d5-819f-e28954d6d7a9"
@@ -237,7 +237,7 @@
     "title": "Leith",
     "address": "12 Bernard Street\nEdinburgh\nEH6 6PP",
     "phone": "0131 555 3907",
-    "hours": "",
+    "hours": "Monday to Friday, 9am to 5pm",
     "lat": 55.9757843,
     "lng": -3.1672877,
     "id": "cabdfee8-acfb-4e22-b619-b7f8f6e38535"
@@ -246,7 +246,7 @@
     "title": "Pilton",
     "address": "661 Ferry Road\nEdinburgh\nEH4 2TX",
     "phone": "0131 555 3907",
-    "hours": "",
+    "hours": "Monday to Friday, 9am to 5pm",
     "lat": 55.9675161,
     "lng": -3.2455201,
     "id": "efe106b0-24f9-43dc-88d7-da9d6991951b"
@@ -255,7 +255,7 @@
     "title": "Portobello",
     "address": "8a - 8b Bath Street\nPortobello\nEH15 1EY",
     "phone": "0131 555 3907",
-    "hours": "",
+    "hours": "Monday to Friday, 9am to 5pm",
     "lat": 55.9533474,
     "lng": -3.1137855,
     "id": "24a48fdd-68d9-4124-ac55-c8803af9b470"
@@ -263,8 +263,8 @@
   {
     "title": "Clackmannanshire",
     "address": "47 Drysdale Street\nAlloa\nFK10 1JA",
-    "phone": "01259 219404",
-    "hours": "",
+    "phone": "01259 404052",
+    "hours": "Monday to Thursday, 10am to 1pm and 2pm to 4pm\nFriday, 10am to 1pm",
     "lat": 56.1161913,
     "lng": -3.793483999999999,
     "id": "e00ab932-4160-455d-a487-a8aaa1a49696"
@@ -273,7 +273,7 @@
     "title": "Clydesdale",
     "address": "10 - 12 Wide Close\nLanark\nML11 7LX",
     "phone": "01555 664 301",
-    "hours": "",
+    "hours": "Monday to Thursday, 10am to 3pm\nFriday, 10am to 12pm",
     "lat": 55.6740258,
     "lng": -3.7802904,
     "id": "db91f640-c85f-4c97-8493-16fb5e0a0e34"
@@ -282,7 +282,7 @@
     "title": "Coatbridge",
     "address": "Unit 10\nFountain Business Centre\nEllis Street\nCoatbridge\nML5 3AA",
     "phone": "01236 421447",
-    "hours": "",
+    "hours": "Monday to Thursday, 10am to 3:45pm\nFriday, 10am to 12pm",
     "lat": 55.8612627,
     "lng": -4.0286997,
     "id": "c9600eda-d142-4b99-82bb-1fd2a227619e"
@@ -291,7 +291,7 @@
     "title": "Cumbernauld and Kilsyth",
     "address": "2 Annan House\n3rd Floor\nTown Centre\nCumbernauld\nG67 1DP",
     "phone": "01236 735165",
-    "hours": "",
+    "hours": "Monday to Friday, 10am to 3pm",
     "lat": 55.9468624,
     "lng": -3.9907348,
     "id": "7e09a502-997d-401d-8ac5-f78b967ee829"
@@ -300,7 +300,7 @@
     "title": "Dalkeith & District",
     "address": "8 Buccleuch Street\nDalkeith\nEH22 1HA",
     "phone": "0131 660 1636",
-    "hours": "",
+    "hours": "Monday to Thursday, 10am to 12:30pm and 1pm to 3pm",
     "lat": 55.8928767,
     "lng": -3.0714093,
     "id": "de5a9adb-13c7-4a8e-aa3a-b456ea551b55"
@@ -309,7 +309,7 @@
     "title": "Denny and Dunipace",
     "address": "24 Duke Street\nDenny\nFK6 6DD",
     "phone": "01324 485290",
-    "hours": "",
+    "hours": "Monday to Friday, 9am to 4pm",
     "lat": 56.0230711,
     "lng": -3.9088867,
     "id": "c5814777-1f92-455f-9b34-0920f2b9cd3d"
@@ -318,16 +318,16 @@
     "title": "Dumfries",
     "address": "81-85 Irish Street\nDumfries\nDG1 2PQ",
     "phone": "0300 303 4321",
-    "hours": "",
+    "hours": "Monday to Friday, 9am to 5pm",
     "lat": 55.0672297,
     "lng": -3.6114505,
     "id": "167c9f8d-755d-4ab5-b4b3-adcc7af96cb2"
   },
   {
     "title": "Dundee",
-    "address": "Dundee Central Library\nLevel 4 Wellgate Centre\nDundee\nDD1 2DB",
+    "address": "Dundee Central Library\nLevel 4 Wellgate Centre\nDundee\nDD1 1DB",
     "phone": "01382 431581",
-    "hours": "",
+    "hours": "Monday, Tuesday, Thursday, 9:30am to 4pm\nWednesday, 10am to 4pm\nFriday, 9:30am to 12pm",
     "lat": 56.4638925,
     "lng": -2.9694461,
     "id": "210ce462-58bf-4c65-b2ce-154cd9abe9da"
@@ -336,7 +336,7 @@
     "title": "Cumnock",
     "address": "77a Townhead Street\nCumnock\nKA18 1LF",
     "phone": "01290 429500",
-    "hours": "",
+    "hours": "Alternate Monday and Friday, 10am to 1pm\nTuesday, Thursday, 10am to 2pm",
     "lat": 55.45442389999999,
     "lng": -4.2621638,
     "id": "ef9f327d-d57b-47b5-81e1-9d83e3b5db2d"
@@ -345,7 +345,7 @@
     "title": "Kilmarnock",
     "address": "3 John Dickie Street\nKilmarnock\nKA1 1HW",
     "phone": "01563 544744",
-    "hours": "",
+    "hours": "Monday, Friday, 10am to 2:30pm\nClosed last Friday of the month\nTuesday, Thursday, 10am to 3pm\n3rd Thursday of the month, 3:30pm to 7:30pm\nWednesday, 9:30am to 3:30pm\nLast Saturday of the month, 10am to 1pm",
     "lat": 55.61016799999999,
     "lng": -4.4991595,
     "id": "1ef49a6b-efc9-4b24-9466-4a079e5cc546"
@@ -354,7 +354,7 @@
     "title": "Bishopbriggs",
     "address": "Unit 5\nSpringfield House,\nEmerson Road\nBishopbriggs\nG64 1QE",
     "phone": "0141 563 0220",
-    "hours": "",
+    "hours": "Monday to Friday, 10am to 3pm",
     "lat": 55.903352,
     "lng": -4.2226129,
     "id": "8fde0339-8164-498c-bee4-fc0c2e65870b"
@@ -363,7 +363,7 @@
     "title": "Kirkintilloch",
     "address": "11 Alexandra Street\nKirkintilloch\nG66 1HB",
     "phone": "0141 775 3220",
-    "hours": "",
+    "hours": "Monday, 10am to 3pm and 5pm to 7pm\nTuesday, Wednesday, Thursday, 10am to 3:30pm\nFriday, 10am to 3pm\nSaturday, 10am to 12pm",
     "lat": 55.9381408,
     "lng": -4.155945099999999,
     "id": "75ceb56c-a17b-430c-8f46-ba4db12cb3d2"
@@ -372,7 +372,7 @@
     "title": "East Kilbride",
     "address": "9 Olympia Way\nTown Centre\nEast Kilbride\nG74 1JT",
     "phone": "01355 263698",
-    "hours": "",
+    "hours": "Monday, Tuesday, Thursday, Friday, 9:30am to 4pm\nWednesday, 10am to 1pm",
     "lat": 55.7603344,
     "lng": -4.1737161,
     "id": "050da183-dead-4525-a685-65f92435faf2"
@@ -381,7 +381,7 @@
     "title": "East Renfrewshire",
     "address": "216 Main Street\nBarrhead\nG78 1SN",
     "phone": "0141 881 2032",
-    "hours": "",
+    "hours": "Monday, Tuesday, Thursday, Friday, 9:30am to 3:30pm\nWednesday, 9:30am to 6pm",
     "lat": 55.8015643,
     "lng": -4.3872873,
     "id": "f1b32460-99c4-4719-b6a8-e44b3d16a0c0"
@@ -389,8 +389,8 @@
   {
     "title": "Golspie",
     "address": "Station Road\nGolspie\nKW10 6SN",
-    "phone": "01408 634410",
-    "hours": "",
+    "phone": "01408 633000",
+    "hours": "Monday to Thursday, 10am to 1pm and 2pm to 4pm\nFriday, 10am to 1pm",
     "lat": 57.9722735,
     "lng": -3.9827167,
     "id": "ccc73c1c-426f-437d-9b2d-e91239891b77"
@@ -399,7 +399,7 @@
     "title": "Falkirk",
     "address": "27-29 Vicar Street\nFalkirk\nFK1 1LL",
     "phone": "01324 485290",
-    "hours": "",
+    "hours": "Monday to Friday, 9am to 4pm",
     "lat": 56.0008822,
     "lng": -3.7841002,
     "id": "5d96aacc-9340-4d44-8273-c4a831ff0d31"
@@ -408,7 +408,7 @@
     "title": "Bridgeton",
     "address": "35 Main Street\nGlasgow\nG40 1QB",
     "phone": "0141 554 0336",
-    "hours": "",
+    "hours": "Monday to Friday, 9am to 4pm\n2nd and 4th Saturday of the month, 10am to 1pm",
     "lat": 55.8478003,
     "lng": -4.2265999,
     "id": "f828eb49-dc4f-4fbc-ad73-ff31cff00fe1"
@@ -417,7 +417,7 @@
     "title": "Castlemilk",
     "address": "27 Dougrie Drive\nCastlemilk\nGlasgow\nG45 9AD",
     "phone": "0141 634 0338",
-    "hours": "",
+    "hours": "Monday to Thursday, 9am to 1pm and 1:30pm to 4:30",
     "lat": 55.8072105,
     "lng": -4.234699,
     "id": "811099c3-5e6d-46cf-ad6e-02fe370717ae"
@@ -426,7 +426,7 @@
     "title": "Glasgow Central",
     "address": "1st Floor\n88 Bell Street\nGlasgow\nG1 1LQ",
     "phone": "0141 559 6290",
-    "hours": "",
+    "hours": "Monday to Friday, 9am to 5pm",
     "lat": 55.8575752,
     "lng": -4.243297399999999,
     "id": "0ba85379-e906-4b86-8c62-c28935d16217"
@@ -435,7 +435,7 @@
     "title": "Drumchapel",
     "address": "195C Drumry Road East\nGlasgow\nG15 8NS",
     "phone": "0141 944 7398",
-    "hours": "",
+    "hours": "Monday, Thursday, 10am to 12:30pm and 2pm to 5pm\nTuesday, Friday, 9:30am to 12:30pm and 2pm to 5pm\nWednesday, 9:30am to 12:30pm and 2pm to 5pm\nAlternate Wednesdays, 5pm to 7pm\n1st and 3rd Saturday of the month, 9:30am to 11:30am",
     "lat": 55.9084595,
     "lng": -4.3750212,
     "id": "0c686436-de02-4d92-8dc7-26c97bb7c5bb"
@@ -444,7 +444,7 @@
     "title": "Easterhouse",
     "address": "46 Shandwick Square\nGlasgow\nG34 9DT",
     "phone": "0141 771 2328",
-    "hours": "",
+    "hours": "Monday, Wednesday, Friday, 9:30am to 4pm\nTuesday, Thursday, 9:30am to 5pm\n1st Saturday of the month, 10am to 1pm",
     "lat": 55.8677966,
     "lng": -4.1230551,
     "id": "56c1ddbf-0fb5-4db4-8fb1-fc5b588a2532"
@@ -453,7 +453,7 @@
     "title": "Greater Pollok",
     "address": "Pollok Civic Realm\n27 Cowglen Road\nGlasgow\nG53 6EW",
     "phone": "0141 876 4401",
-    "hours": "",
+    "hours": "Monday, 9am to 12:30pm and 1pm to 5pm\nTuesday, 9am to 7pm\nWednesday, Thursday, Friday, 9am to 5pm\n2nd Saturday of the month, 10am to 12:30pm",
     "lat": 55.8229524,
     "lng": -4.3455998,
     "id": "b3126c66-1b09-4775-bdac-10da6dea2ba3"
@@ -462,7 +462,7 @@
     "title": "Possilpark",
     "address": "160-162 Saracen Street\nPossilpark\nGlasgow\nG22 5AS",
     "phone": "0141 336 3405",
-    "hours": "",
+    "hours": "Monday to Friday, 9:30am to 5pm",
     "lat": 55.8820387,
     "lng": -4.253980400000001,
     "id": "b590426b-8154-45b1-8d17-c562f06cc281"
@@ -471,7 +471,7 @@
     "title": "Maryhill",
     "address": "25 Avenuepark Street\nGlasgow\nG20 8TS",
     "phone": "0141 946 6373",
-    "hours": "",
+    "hours": "Monday to Friday, 9:30am to 5pm",
     "lat": 55.8851251,
     "lng": -4.2823062,
     "id": "c223779a-d18d-4544-8162-49e79069ad54"
@@ -480,7 +480,7 @@
     "title": "Parkhead",
     "address": "1361 - 1363 Gallowgate\nGlasgow\nG31 4DN",
     "phone": "0141 554 0004",
-    "hours": "",
+    "hours": "Monday, Friday, 9am to 5pm\nTuesday, Thursday, 10am to 3:30pm\nWednesday, 9am to 7:30pm",
     "lat": 55.8522463,
     "lng": -4.1998182,
     "id": "d0cd2b5a-27dc-4d1d-8d3b-d7b93b5afd4a"
@@ -489,7 +489,7 @@
     "title": "Grangemouth",
     "address": "1 Kerse Road\nGrangemouth\nFK3 8HW",
     "phone": "01324 485290",
-    "hours": "",
+    "hours": "Monday to Friday, 9am to 4pm",
     "lat": 56.01781889999999,
     "lng": -3.7242684,
     "id": "6d0f4779-d3db-4630-aca0-49b3ad0fe52e"
@@ -498,7 +498,7 @@
     "title": "Haddington",
     "address": "46 Court Street\nHaddington\nEH41 3NP",
     "phone": "01620 824471",
-    "hours": "",
+    "hours": "Monday to Friday, 10am to 4pm",
     "lat": 55.9559588,
     "lng": -2.7812391,
     "id": "e03fcdbb-47a5-4c1b-b5a5-82fdaa64ba5d"
@@ -507,7 +507,7 @@
     "title": "Hamilton",
     "address": "Almada Tower\n67 Almada Street\nHamilton\nML3 OHQ",
     "phone": "01698 283477",
-    "hours": "",
+    "hours": "Monday to Thursday, 9am to 4pm\nFriday, 9am to 3:30pm",
     "lat": 55.7788839,
     "lng": -4.0483221,
     "id": "9b63ac8f-c239-4ec6-a118-b6c0b9c707a8"
@@ -516,7 +516,7 @@
     "title": "Harris",
     "address": "Pier Road\nTarbert\nHS3 3BG",
     "phone": "01859 502431",
-    "hours": "",
+    "hours": "Monday, Tuesday, 9am to 12pm\nWednesday, Thursday, Friday, 9am to 4pm",
     "lat": 57.89771409999999,
     "lng": -6.798449100000001,
     "id": "6ea75339-4984-4480-9288-4d8aae0272d8"
@@ -525,7 +525,7 @@
     "title": "Inverness",
     "address": "103 Academy Street\nInverness\nIV1 1LX",
     "phone": "01463 237664",
-    "hours": "",
+    "hours": "Monday to Friday, 10am to 4pm\nSaturday, 9:30am to 4pm",
     "lat": 57.4807265,
     "lng": -4.2280107,
     "id": "aba2e538-2866-43c4-aa17-2f6bc734677a"
@@ -533,35 +533,38 @@
   {
     "title": "Aviemore",
     "address": "2 Inverewe\nGrampian Road\nAviemore\nPH22 1RH",
-    "phone": "01479 810919",
+    "phone": "",
     "hours": "",
     "lat": 57.18955589999999,
     "lng": -3.8290538,
-    "id": "69924b24-044f-49ea-bca5-306b23e60531"
+    "id": "69924b24-044f-49ea-bca5-306b23e60531",
+    "booking_location_id": "aba2e538-2866-43c4-aa17-2f6bc734677a"
   },
   {
     "title": "Grantown-on-Spey",
     "address": "41C High Street\nGrantown on Spey\nPH26 3EG",
-    "phone": "01479 810919",
+    "phone": "",
     "hours": "",
     "lat": 57.3299171,
     "lng": -3.6096264,
-    "id": "5ecf97f4-29f6-4173-97ab-faa2ac9cdbcc"
+    "id": "5ecf97f4-29f6-4173-97ab-faa2ac9cdbcc",
+    "booking_location_id": "aba2e538-2866-43c4-aa17-2f6bc734677a"
   },
   {
     "title": "Inverness (Raigmore Hospital)",
     "address": "Raigmore Hospital\nOld Perth Road\nInverness\nIV2 3UJ",
-    "phone": "01463 706014",
+    "phone": "",
     "hours": "",
     "lat": 57.47432999999999,
     "lng": -4.192495399999999,
-    "id": "cd256fe7-9378-49c8-9abc-7e00d5eac221"
+    "id": "cd256fe7-9378-49c8-9abc-7e00d5eac221",
+    "booking_location_id": "aba2e538-2866-43c4-aa17-2f6bc734677a"
   },
   {
     "title": "Irvine",
     "address": "22A Eglinton Street\nIrvine\nKA12 8AS",
     "phone": "01294 608 147",
-    "hours": "",
+    "hours": "Monday, Tuesday, Friday, 9am to 1pm",
     "lat": 55.6171944,
     "lng": -4.6684287,
     "id": "7ba7fee9-280e-4033-8d67-b3809ea428ea"
@@ -570,7 +573,7 @@
     "title": "Kilbirnie",
     "address": "43 Main Street\nKilbirnie\nKA25 7BX",
     "phone": "01294 608 147",
-    "hours": "",
+    "hours": "Thursday, 10am to 2pm",
     "lat": 55.75499420000001,
     "lng": -4.685559899999999,
     "id": "2305088a-e842-45d4-bcef-7878cb451454"
@@ -579,7 +582,7 @@
     "title": "Kincardine and Mearns",
     "address": "9 Cameron Street\nStonehaven\nAB39 2BL",
     "phone": "01569 766 578",
-    "hours": "",
+    "hours": "Monday, 9:30am to 3:30pm\nWednesday, 9:30am to 12:30pm and 4:30pm to 7pm\nThursday, Friday, 9:30am to 12pm",
     "lat": 56.9629497,
     "lng": -2.208823,
     "id": "4e9842bc-7b3a-44c8-bb54-b8cd1bd9fe3e"
@@ -588,7 +591,7 @@
     "title": "Largs",
     "address": "32-34 Boyd Street\nLargs\nKA30 8LE",
     "phone": "01294 608 147",
-    "hours": "",
+    "hours": "Monday, Tuesday, Wednesday, 10am to 2pm",
     "lat": 55.7961554,
     "lng": -4.866681199999999,
     "id": "f44b84db-4705-4cb4-87d0-7ec560835b70"
@@ -597,7 +600,7 @@
     "title": "Lewis",
     "address": "41-43 Westview Terrace\nStornoway\nHS1 2HP",
     "phone": "01851 705727",
-    "hours": "",
+    "hours": "Monday, Tuesday, Thursday, Friday, 10am to 12:45pm and 2pm to 3:30pm\nWednesday, 10am to 12:45pm",
     "lat": 58.2154924,
     "lng": -6.3818457,
     "id": "88905b48-61ad-4c8c-b811-c4c2cdb117e5"
@@ -606,16 +609,16 @@
     "title": "Lochaber",
     "address": "Dudley Road\nLochaber\nFort William\nPH33 6JB",
     "phone": "01397 705311",
-    "hours": "",
+    "hours": "Monday, Tuesday, Thursday, Friday, 10am to 2pm\nWednesday, 3pm to 6pm",
     "lat": 56.81834809999999,
     "lng": -5.1083136,
     "id": "d8d31ec5-9a49-4f2a-8f15-2290225c51f3"
   },
   {
     "title": "Moray",
-    "address": "6 Moss Street\nElgin\nIV30 1LU",
+    "address": "6 Moss Street\nElgin\nMoray\nIV30 1LU",
     "phone": "01343 550088",
-    "hours": "",
+    "hours": "Monday, Friday, 9:30am to 12pm\nTuesday, Thursday, 9:30am to 12pm, 1pm to 3:30pm and 5pm to 7pm\nWednesday, 9:30am to 12pm and 1pm to 3:30pm",
     "lat": 57.6471904,
     "lng": -3.3121999,
     "id": "25d212ed-7d96-457b-a2fc-14a55bd312d3"
@@ -624,7 +627,7 @@
     "title": "Motherwell & Wishaw",
     "address": "32 Civic Square\nMotherwell\nML1 1TP",
     "phone": "01698 265349",
-    "hours": "",
+    "hours": "Monday to Friday, 9am to 5pm",
     "lat": 55.7847424,
     "lng": -3.983301499999999,
     "id": "818bda02-543c-4a8f-9eb4-69178e787596"
@@ -633,7 +636,7 @@
     "title": "Musselburgh",
     "address": "141 High Street\nMusselburgh\nEH21 7DD",
     "phone": "0131 653 2748",
-    "hours": "",
+    "hours": "Monday to Thursday, 10am to 12:30pm and 1:30pm to 4pm\nFriday 10am to 12:30pm",
     "lat": 55.9424639,
     "lng": -3.0517583,
     "id": "1e2f4e66-20be-4852-9911-11b94144dbce"
@@ -642,7 +645,7 @@
     "title": "Nairn",
     "address": "6 High Street\nNairn\nIV12 4BJ",
     "phone": "01667 456677",
-    "hours": "",
+    "hours": "Monday, Tuesday, Wednesday, Friday, 9am to 4pm\nThursday, 9am to 7pm\nSaturday 10am to 1pm",
     "lat": 57.5837982,
     "lng": -3.8704429,
     "id": "2924c6b3-f4b6-408c-ace2-084437a9943f"
@@ -651,7 +654,7 @@
     "title": "North and West Sutherland",
     "address": "The Pier\nKinlochbervie\nIV27 4RR",
     "phone": "01971 521 730",
-    "hours": "",
+    "hours": "Monday to Friday, 9:30am to 1pm and 2pm to 4:30pm",
     "lat": 58.4585297,
     "lng": -5.0523766,
     "id": "1e1d1b46-fe65-4131-8512-8df2c68b920e"
@@ -660,7 +663,7 @@
     "title": "Orkney",
     "address": "Anchor Buildings,\n6 Bridge Street\nKirkwall\nKW15 1HR",
     "phone": "01856 875266",
-    "hours": "",
+    "hours": "Monday to Friday, 9am to 5pm",
     "lat": 58.98419080000001,
     "lng": -2.9583093,
     "id": "d224e094-11ec-4949-b613-135d53035c56"
@@ -669,7 +672,7 @@
     "title": "Peebles",
     "address": "Chambers Institution\nHigh Street\nPeebles\nEH45 8AJ",
     "phone": "01721 721722",
-    "hours": "",
+    "hours": "Monday, 10am to 4pm\nTuesday to Friday, 10am to 1pm",
     "lat": 55.65160479999999,
     "lng": -3.1904812,
     "id": "3f963bc4-9b22-4d51-8fa8-ddc36d987c77"
@@ -678,7 +681,7 @@
     "title": "Penicuik",
     "address": "14a John Street\nPenicuik\nEH26 8AB",
     "phone": "01968 675259",
-    "hours": "",
+    "hours": "Monday to Thursday, 9:30am to 3:30pm\nFriday, 9:30am to 1:30pm",
     "lat": 55.8275076,
     "lng": -3.2224102,
     "id": "3de41c57-6fec-45f4-acc9-8610eca1de3a"
@@ -687,7 +690,7 @@
     "title": "Perth",
     "address": "7 Atholl Crescent\nPerth\nPH1 5NG",
     "phone": "01738 450596",
-    "hours": "",
+    "hours": "Monday to Friday, 9am to 5pm",
     "lat": 56.3991803,
     "lng": -3.4313131,
     "id": "70710524-824d-4e22-a2c1-c0a0c94ba79d"
@@ -696,25 +699,25 @@
     "title": "Renfrewshire",
     "address": "45 George Street\nPaisley\nPA1 2JY",
     "phone": "0141 375 7328",
-    "hours": "",
+    "hours": "Monday, 10am to 3:30pm and 5pm to 7pm\nTuesday to Thursday, 10am to 3:30pm\nFriday, 9am to 3:30pm",
     "lat": 55.8421724,
     "lng": -4.430813,
     "id": "a0256c3a-6a60-4acd-b2dd-8b339c8ed75a"
   },
   {
     "title": "Alness",
-    "address": "Balallan,\n4 Novar Road\nAlness\nIV17 0QG",
+    "address": "Suie House\nMarket Square\nAlness\nIV17 0UD",
     "phone": "01349 883333",
-    "hours": "",
-    "lat": 57.69628319999999,
-    "lng": -4.2597897,
+    "hours": "Monday to Friday, 10am to 2pm\nWednesday, 4pm to 7pm",
+    "lat": 57.695387,
+    "lng": -4.247865,
     "id": "982a0299-3f39-45f9-abc3-61ce0add30b6"
   },
   {
     "title": "Roxburgh and Berwickshire",
     "address": "1 Towerdykeside\nHawick\nTD9 9EA",
     "phone": "01450 374266",
-    "hours": "",
+    "hours": "Monday, Tuesday, Thursday, 10am to 4pm\nTuesday, 10am to 1pm\nFriday, 10am to 3pm",
     "lat": 55.42135709999999,
     "lng": -2.7874585,
     "id": "76557407-0fb2-4b94-a6a8-67f6e34d207e"
@@ -723,7 +726,7 @@
     "title": "Cambuslang",
     "address": "Kyle Court\n17 Main Street\nCambuslang\nG72 7EX",
     "phone": "0141 646 3191",
-    "hours": "",
+    "hours": "Monday to Friday, 10am to 3pm\nThursday, 10am to 12pm and 1:30am to 3pm",
     "lat": 55.8188938,
     "lng": -4.165875,
     "id": "4ab008a6-72d5-4b36-b683-48eb0c527beb"
@@ -732,7 +735,7 @@
     "title": "Saltcoats",
     "address": "87 Dockhead Street\nSaltcoats\nKA21 5ED",
     "phone": "01294 608 147",
-    "hours": "",
+    "hours": "Monday to Friday, 10am to 2pm",
     "lat": 55.63292810000001,
     "lng": -4.7871305,
     "id": "793e1b97-429d-4a6e-806c-ec07f5984211"
@@ -740,8 +743,8 @@
   {
     "title": "Shetland Islands",
     "address": "Market House,\n14 Market Street\nLerwick\nZE1 0JP",
-    "phone": "01595 744596",
-    "hours": "",
+    "phone": "01595 694696",
+    "hours": "Monday to Friday, 9:30am to 12:30pm and 2pm to 4pm",
     "lat": 60.15555860000001,
     "lng": -1.1461098,
     "id": "1f82d904-a323-4af5-83f3-33943141e1d4"
@@ -750,7 +753,7 @@
     "title": "Skye and Lochalsh",
     "address": "The Green\nPortree\nIV51 9BT",
     "phone": "01478 612032",
-    "hours": "",
+    "hours": "Monday, Tuesday, Thursday, 10am to 1pm and 2pm to 4:30pm\nWednesday, 10am to 1pm",
     "lat": 57.41256139999999,
     "lng": -6.194899800000001,
     "id": "7007f2be-d1c0-4dbe-a6fe-737b8d2e8bd0"
@@ -759,7 +762,7 @@
     "title": "South West Aberdeenshire",
     "address": "Suite 2\n1st Floor Offices\nWesthill Shopping Centre\nOld Skene Road\nWesthill\nAB32 6RL",
     "phone": "01224 747714",
-    "hours": "",
+    "hours": "Monday to Friday, 9am to 5pm",
     "lat": 57.15401499999999,
     "lng": -2.27843,
     "id": "3530de46-c1a3-4b9b-99f1-51d3878068bb"
@@ -768,7 +771,7 @@
     "title": "Stirling",
     "address": "The Norman MacEwan Centre\nCameronian Street\nStirling\nFK8 2DX",
     "phone": "01786 470239",
-    "hours": "",
+    "hours": "Monday to Thursday, 10am to 3pm",
     "lat": 56.11633930000001,
     "lng": -3.9355092,
     "id": "d566c947-1b34-4b89-b55a-6d5aaff8385a"
@@ -777,7 +780,7 @@
     "title": "Stranraer",
     "address": "23 Lewis Street\nStranraer\nDG9 7AB",
     "phone": "0300 303 4321",
-    "hours": "",
+    "hours": "Monday, 9am to 7pm\nTuesday to Friday, 9am to 5pm",
     "lat": 54.9029482,
     "lng": -5.0270678,
     "id": "ced01a69-7a4d-4bac-a6b5-28c1c5c31679"
@@ -786,7 +789,7 @@
     "title": "Turriff",
     "address": "Masonic Building\nGladstone Terrace\nTurriff\nAB53 4AT",
     "phone": "01888 562 495",
-    "hours": "",
+    "hours": "Monday, Thursday, 9:30am to 3:30pm\nTuesday, 9:30am to 7pm\nWednesday, Friday, 9:30am to 12:30pm",
     "lat": 57.5398496,
     "lng": -2.4637553,
     "id": "562f5626-5e9d-43bf-86de-cca89ecb310e"
@@ -795,7 +798,7 @@
     "title": "Uist",
     "address": "45 Winfield Way\nBalivanich\nHS7 5LH",
     "phone": "01870 602421",
-    "hours": "",
+    "hours": "Monday, Tuesday, Thursday, Friday, 10.30am to 12.30pm and 2pm to 4pm",
     "lat": 57.4731067,
     "lng": -7.388172699999999,
     "id": "b88818f2-3ab9-4a04-a51a-e416a1af0ad3"
@@ -804,7 +807,7 @@
     "title": "Dumbarton",
     "address": "Bridgend House\n179 High Street\nDumbarton\nG82 1NW",
     "phone": "01389 744 693",
-    "hours": "",
+    "hours": "Tuesday to Friday, 9:30am to 3:30pm",
     "lat": 55.9431376,
     "lng": -4.570066499999999,
     "id": "14d99fda-8707-4543-94dc-737fad7d8a1e"
@@ -813,7 +816,7 @@
     "title": "Clydebank",
     "address": "Social Economy Centre\n63 Kilbowie Road\nClydebank\nG81 1BL",
     "phone": "01389 744 693",
-    "hours": "",
+    "hours": "Tuesday to Friday, 9:30am to 3:30pm",
     "lat": 55.90205479999999,
     "lng": -4.4058514,
     "id": "1309ee8b-c6a1-4277-bc12-a96c5b8fca79"
@@ -822,7 +825,7 @@
     "title": "Alexandria",
     "address": "77 Bank Street\nAlexandria\nG83 0LW",
     "phone": "01389 752 727",
-    "hours": "",
+    "hours": "Monday, Wednesday to Friday, 9:30am to 3:30pm",
     "lat": 55.986670,
     "lng": -4.578689,
     "id": "8f8dd4f4-ce83-4cdc-aaac-805e25e78615"


### PR DESCRIPTION
This is mostly the addition of Scottish bureaux opening hours. Some of the them are a bit convoluted but I've done my best to simply them, for example:

![image](https://cloud.githubusercontent.com/assets/45121/9936480/200d5f8a-5d54-11e5-9286-657782bd2256.png)

Would be good to get @andrewgarner to have a glance to see how these fit in with the GOV.UK style we're using to communicate opening hours.

A small number of updates affected addresses and only 1 of these necessitated amending lat/lngs by my reckoning.

A few updates concerned phone numbers so my next move is to tweak `switchboard` accordingly. **Note**: _Aviemore_, _Grantown-on-Spey_ and _Inverness (Raigmore Hospital)_ are now the first CAS delivery locations to use a separate booking location, _Inverness_ in this instance.
